### PR TITLE
Fix misaki-rs Portability & Build Issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.114",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +82,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "cc"
+version = "1.2.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,7 +114,23 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
+ "libloading",
 ]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -96,22 +145,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "espeakng"
-version = "0.2.0"
-source = "git+https://github.com/GnomedDev/espeakNG-rs#df773d73cb5c100f305c4230e3378ba7b9ed2ebc"
+name = "espeak-rs"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d648355e4824dd2b37fcc84af3cbc234f96ae4f7c515fea2df7094f98453edd0"
 dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "errno",
- "espeakng-sys",
- "libc",
+ "espeak-rs-sys",
+ "ffi-support",
  "once_cell",
- "parking_lot",
- "strum_macros 0.25.3",
+ "regex",
+]
+
+[[package]]
+name = "espeak-rs-sys"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb333310ae915d57961a6bbc67f53ef7b313a9ee80d393d55c0f27f1b65c848"
+dependencies = [
+ "bindgen 0.69.5",
+ "cmake",
+ "glob",
 ]
 
 [[package]]
@@ -120,7 +177,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd3ba97ca1071b8b8b17cf933180a7baa0142841bb03c5b8a5057c68c5c522b"
 dependencies = [
- "bindgen",
+ "bindgen 0.62.0",
 ]
 
 [[package]]
@@ -133,6 +190,22 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "ffi-support"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27838c6815cfe9de2d3aeb145ffd19e565f577414b33f3bdbf42fe040e9e0ff6"
+dependencies = [
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "glob"
@@ -148,15 +221,18 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "indexmap"
@@ -166,6 +242,15 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -183,7 +268,7 @@ dependencies = [
  "num_enum",
  "strsim",
  "strum",
- "strum_macros 0.27.2",
+ "strum_macros",
  "thiserror",
  "unicode-normalization",
  "unicode-segmentation",
@@ -209,13 +294,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
+name = "libloading"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "scopeguard",
+ "cfg-if",
+ "windows-link",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -233,7 +331,8 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 name = "misaki-rs"
 version = "0.2.0"
 dependencies = [
- "espeakng",
+ "espeak-rs",
+ "espeakng-sys",
  "fancy-regex",
  "language-tokenizer",
  "num2words",
@@ -288,29 +387,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +397,16 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -347,15 +433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -394,16 +471,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -455,12 +539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,20 +550,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.114",
+ "strum_macros",
 ]
 
 [[package]]
@@ -494,7 +559,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -646,10 +711,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16a3e068c98d5736c4b5d2dfc0ab9f3b1dcb8f9dbc5a22bde166550c5d3788c0"
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -659,6 +745,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "thiserror",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 fancy-regex = "0.13"
 language-tokenizer = { version = "0.1", features = ["snowball"] }
-espeakng = { git = "https://github.com/GnomedDev/espeakNG-rs" }
+espeak-rs = "0.1.9"
+espeakng-sys = { version = "0.2.0", features = ["clang-runtime"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ language-tokenizer = { version = "0.1", features = ["snowball"] }
 espeak-rs = "0.1.9"
 espeakng-sys = { version = "0.2.0", features = ["clang-runtime"] }
 tracing = "0.1"
+thiserror = "2.0"

--- a/examples/test_stress_fix.rs
+++ b/examples/test_stress_fix.rs
@@ -4,7 +4,7 @@ fn main() {
     // Test that unknown words use espeak fallback
     let test_unknown = "ilili xyzabc fantabulous";
     let g2p = G2P::new(Language::EnglishUS);
-    let (phonemes, _) = g2p.g2p(test_unknown);
+    let (phonemes, _) = g2p.g2p(test_unknown).unwrap();
 
     println!("Unknown words test: {}", phonemes);
 

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -1,6 +1,5 @@
 use espeak_rs::text_to_phonemes;
 use std::sync::Mutex;
-use tracing::error;
 
 static ESPEAK_MUTEX: Mutex<()> = Mutex::new(());
 
@@ -9,7 +8,7 @@ pub trait Fallback: Send + Sync {
     /// Convert unknown word to phonemes
     /// Returns (phonemes, rating) tuple
     /// Note: espeak-ng is rule-based and always produces output
-    fn phonemize(&self, word: &str) -> (String, u8);
+    fn phonemize(&self, word: &str) -> Result<(String, u8), String>;
 }
 
 /// espeak-ng based fallback
@@ -40,23 +39,20 @@ impl EspeakFallback {
 }
 
 impl Fallback for EspeakFallback {
-    fn phonemize(&self, word: &str) -> (String, u8) {
-        let _lock = ESPEAK_MUTEX.lock().unwrap();
+    fn phonemize(&self, word: &str) -> Result<(String, u8), String> {
+        let _lock = ESPEAK_MUTEX.lock().map_err(|e| format!("mutex poisoned: {:?}", e))?;
         let voice = if self.british { "en" } else { "en-us" };
 
         // Use the portable espeak-rs call (used in kokoros)
         match text_to_phonemes(word, voice, None, true, false) {
             Ok(phonemes) => {
                 if phonemes.is_empty() {
-                    return (word.to_string(), 0);
+                    return Ok((word.to_string(), 0));
                 }
                 let cleaned = self.convert_espeak_to_misaki(&phonemes.join(""));
-                (cleaned, 1)
+                Ok((cleaned, 1))
             }
-            Err(e) => {
-                error!("espeak error for '{}': {:?}", word, e);
-                (word.to_string(), 0)
-            }
+            Err(e) => Err(format!("espeak error for '{}': {:?}", word, e)),
         }
     }
 }
@@ -70,7 +66,7 @@ mod tests {
         let fallback = EspeakFallback::new(false).expect("espeak should initialize");
 
         // Test unknown word - espeak ALWAYS returns something
-        let (phonemes, rating) = fallback.phonemize("ilili");
+        let (phonemes, rating) = fallback.phonemize("ilili").unwrap();
         assert!(!phonemes.is_empty());
         assert_eq!(rating, 1);  // fallback rating
 
@@ -83,14 +79,14 @@ mod tests {
         let fallback = EspeakFallback::new(false).unwrap();
 
         // espeak handles even nonsense words
-        let (phonemes, _) = fallback.phonemize("xyzqwop");
+        let (phonemes, _) = fallback.phonemize("xyzqwop").unwrap();
         assert!(!phonemes.is_empty(), "espeak should phonemize nonsense words");
     }
 
     #[test]
     fn test_espeak_phonemes_beat() {
         let fallback = EspeakFallback::new(false).unwrap();
-        let (phonemes, _) = fallback.phonemize("beat");
+        let (phonemes, _) = fallback.phonemize("beat").unwrap();
         // Misaki for beat should probably be bˈit or similar
         assert!(phonemes.contains("ˈi"), "Should contain stressed i, got: {}", phonemes);
     }
@@ -101,8 +97,8 @@ mod tests {
         let gb = EspeakFallback::new(true).unwrap();
 
         // Test word with different pronunciations
-        let (us_phonemes, _) = us.phonemize("schedule");
-        let (gb_phonemes, _) = gb.phonemize("schedule");
+        let (us_phonemes, _) = us.phonemize("schedule").unwrap();
+        let (gb_phonemes, _) = gb.phonemize("schedule").unwrap();
 
         assert!(!us_phonemes.is_empty());
         assert!(!gb_phonemes.is_empty());

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -1,3 +1,9 @@
+use espeak_rs::text_to_phonemes;
+use std::sync::Mutex;
+use tracing::error;
+
+static ESPEAK_MUTEX: Mutex<()> = Mutex::new(());
+
 /// Trait for OOV (out-of-vocabulary) word fallback mechanisms
 pub trait Fallback: Send + Sync {
     /// Convert unknown word to phonemes
@@ -13,123 +19,45 @@ pub struct EspeakFallback {
 
 impl EspeakFallback {
     pub fn new(british: bool) -> Result<Self, String> {
-        // Initialize espeak-ng
-        // espeak-ng uses IPA output by default which matches misaki
         Ok(Self { british })
+    }
+
+    /// Convert espeak IPA output to misaki phoneme format
+    fn convert_espeak_to_misaki(&self, espeak_ipa: &str) -> String {
+        let mut result = espeak_ipa.to_string();
+
+        // Conversions to match misaki phoneme set
+        result = result.replace("iː", "ˈi").replace("i:", "ˈi");
+        result = result.replace("uː", "ˈu").replace("u:", "ˈu");
+        result = result.replace("ɜː", "ɜ").replace("ɜ:", "ɜ");
+        result = result.replace("ɔː", "ɔ").replace("ɔ:", "ɔ");
+        result = result.replace("ɑː", "ɑ").replace("ɑ:", "ɑ");
+        result = result.replace("ː", ""); // remove remaining length markers
+        result = result.replace("_", ""); // stop syllables
+
+        result.replace("ˈˈ", "ˈ").replace("ˌˌ", "ˌ")
     }
 }
 
 impl Fallback for EspeakFallback {
     fn phonemize(&self, word: &str) -> (String, u8) {
-        use espeakng::{initialise, PhonemeGenOptions, PhonemeMode, TextMode};
-        use tracing::error;
+        let _lock = ESPEAK_MUTEX.lock().unwrap();
+        let voice = if self.british { "en" } else { "en-us" };
 
-        // Initialize espeak (idempotent - safe to call multiple times)
-        let speaker_mutex = match initialise(None) {
-            Ok(s) => s,
-            Err(e) => {
-                error!("espeak init error: {:?}", e);
-                // Return word as-is if espeak unavailable
-                return (word.to_string(), 0);
-            }
-        };
-
-        let mut speaker = speaker_mutex.lock();
-
-        // Select language variant
-        let voice = if self.british {
-            "en"
-        } else {
-            "en-us"
-        };
-
-        if let Err(e) = speaker.set_voice_raw(voice) {
-            error!("espeak set_voice error for '{}': {:?}", voice, e);
-            // Continue anyway, it will use default voice
-        }
-
-        // Convert to phonemes using espeak
-        // espeak is rule-based and ALWAYS produces output
-        let options = PhonemeGenOptions::Standard {
-            text_mode: TextMode::Utf8,
-            // In espeak-ng, value 2 (bit 1) is IPA.
-            // In the espeakng crate, bit 1 is named IncludeZeroWidthJoiners.
-            phoneme_mode: PhonemeMode::IncludeZeroWidthJoiners,
-        };
-
-        match speaker.text_to_phonemes(word, options) {
-            Ok(Some(phonemes)) => {
-                // Clean up phonemes to match misaki format
-                let cleaned = self.convert_espeak_to_misaki(&phonemes);
-                (cleaned, 1)  // rating=1 for fallback
-            },
-            Ok(None) => {
-                (word.to_string(), 0)
+        // Use the portable espeak-rs call (used in kokoros)
+        match text_to_phonemes(word, voice, None, true, false) {
+            Ok(phonemes) => {
+                if phonemes.is_empty() {
+                    return (word.to_string(), 0);
+                }
+                let cleaned = self.convert_espeak_to_misaki(&phonemes.join(""));
+                (cleaned, 1)
             }
             Err(e) => {
-                // Should never happen with valid espeak installation
-                error!("Unexpected espeak error for '{}': {:?}", word, e);
-                // Return word as-is as last resort
+                error!("espeak error for '{}': {:?}", word, e);
                 (word.to_string(), 0)
             }
         }
-    }
-}
-
-impl EspeakFallback {
-    /// Convert espeak IPA output to misaki phoneme format
-    fn convert_espeak_to_misaki(&self, espeak_ipa: &str) -> String {
-        // espeak outputs IPA, misaki uses similar but slightly different symbols
-        // Map espeak's IPA to misaki's phoneme set
-
-        let mut result = espeak_ipa.to_string();
-
-        // Common conversions (based on misaki phoneme set):
-        // espeak uses standard IPA, misaki uses custom symbols
-
-        // Vowels
-        result = result.replace("ɪ", "ɪ");  // same
-        result = result.replace("iː", "ˈi");  // long i -> stressed i
-        result = result.replace("i:", "ˈi");
-        result = result.replace("ʊ", "ʊ");  // same
-        result = result.replace("uː", "ˈu");  // long u -> stressed u
-        result = result.replace("u:", "ˈu");
-        result = result.replace("ɛ", "ɛ");  // same
-        result = result.replace("ə", "ə");  // schwa - same
-        result = result.replace("ɜː", "ɜ");  // remove length marker
-        result = result.replace("ɜ:", "ɜ");
-        result = result.replace("ɔː", "ɔ");  // remove length marker
-        result = result.replace("ɔ:", "ɔ");
-        result = result.replace("æ", "æ");  // same
-        result = result.replace("ʌ", "ʌ");  // same
-        result = result.replace("ɑː", "ɑ");  // remove length marker
-        result = result.replace("ɑ:", "ɑ");
-
-        // Consonants (mostly same in espeak and misaki)
-        result = result.replace("ŋ", "ŋ");  // ng
-        result = result.replace("ʃ", "ʃ");  // sh
-        result = result.replace("ʒ", "ʒ");  // zh
-        result = result.replace("θ", "θ");  // th (thin)
-        result = result.replace("ð", "ð");  // th (this)
-        result = result.replace("ɹ", "ɹ");  // r
-        result = result.replace("ʤ", "ʤ");  // j (judge)
-        result = result.replace("ʧ", "ʧ");  // ch
-
-        // Stress markers - espeak uses ' for primary, ˌ for secondary
-        // Keep as-is (matches misaki)
-
-        // Remove espeak-specific markers we don't need
-        result = result.replace("ː", "");  // length marker
-        result = result.replace("_", "");  // syllable boundaries
-
-        // Final cleanup: remove duplicate stress markers that might have been
-        // introduced by our mappings if espeak already had a stress marker
-        result = result.replace("ˈˈ", "ˈ");
-        result = result.replace("ˌˌ", "ˌ");
-        result = result.replace("ˈˌ", "ˈ");
-        result = result.replace("ˌˈ", "ˌ");
-
-        result
     }
 }
 

--- a/src/g2p.rs
+++ b/src/g2p.rs
@@ -1,12 +1,19 @@
 use crate::language::Language;
-use crate::fallback::{Fallback, EspeakFallback};
+use crate::fallback::{Fallback, EspeakFallback, FallbackError};
 use crate::languages::{LanguageRules, english::English};
 use crate::lexicon::Lexicon;
+use thiserror::Error;
 use crate::tagger::PerceptronTagger;
 use crate::token::MToken;
 use num2words::Num2Words;
 use regex::Regex;
 use std::collections::HashMap;
+
+#[derive(Error, Debug)]
+pub enum G2PError {
+    #[error("fallback error: {0}")]
+    Fallback(#[from] FallbackError),
+}
 
 pub struct G2P {
     pub lexicon: Lexicon,
@@ -103,7 +110,7 @@ impl G2P {
         tokens
     }
 
-    pub fn g2p(&self, text: &str) -> (String, Vec<MToken>) {
+    pub fn g2p(&self, text: &str) -> Result<(String, Vec<MToken>), G2PError> {
         let (processed_text, _, _) = self.preprocess(text);
         let mut tokens = self.tokenize(&processed_text);
 
@@ -178,14 +185,14 @@ impl G2P {
                         let parts: Vec<&str> = word.split('-').filter(|s| !s.is_empty()).collect();
                         let mut sub_ps = Vec::new();
                         for part in parts {
-                            let (p, _) = self.g2p(part);
+                            let (p, _) = self.g2p(part)?;
                             sub_ps.push(p);
                         }
                         tokens[i].phonemes = Some(sub_ps.join(" "));
                     } else if self.is_number(&word) {
                         let spoken = self.convert_number(&word);
                         if spoken != word {
-                            let (p, _) = self.g2p(&spoken);
+                            let (p, _) = self.g2p(&spoken)?;
                             tokens[i].phonemes = Some(p);
                         }
                     }
@@ -203,12 +210,13 @@ impl G2P {
                         let mut handled = false;
                         if let Some(ref fallback) = self.fallback {
                             match fallback.phonemize(&word) {
-                                Ok((ps, _)) => {
+                                Ok(ps) => {
                                     tokens[i].phonemes = Some(ps);
                                     handled = true;
                                 }
                                 Err(e) => {
-                                    tracing::error!("fallback error: {}", e);
+                                    tracing::error!("fallback error for '{}': {}", word, e);
+                                    return Err(G2PError::Fallback(e));
                                 }
                             }
                         }
@@ -217,7 +225,7 @@ impl G2P {
                             // No fallback available or failed, try character-by-character
                             let mut char_ps = Vec::new();
                             for c in word.chars() {
-                                let (p, _) = self.g2p(&c.to_string());
+                                let (p, _) = self.g2p(&c.to_string())?;
                                 char_ps.push(p);
                             }
                             tokens[i].phonemes = Some(char_ps.join(" "));
@@ -240,7 +248,7 @@ impl G2P {
                             .collect();
 
                         if normalized != word {
-                            let (p, _) = self.g2p(&normalized);
+                            let (p, _) = self.g2p(&normalized)?;
                             tokens[i].phonemes = Some(p);
                         } else {
                             // Handle standard punctuation and symbols gracefully
@@ -281,7 +289,7 @@ impl G2P {
             .map(|tk| tk.phonemes.as_ref().unwrap_or(&self.unk).clone() + &tk.whitespace)
             .collect::<String>();
 
-        (result, tokens)
+        Ok((result, tokens))
     }
 
     fn is_number(&self, word: &str) -> bool {
@@ -311,7 +319,7 @@ mod tests {
     #[test]
     fn test_g2p_basic() {
         let g2p = G2P::new(Language::EnglishUS);
-        let (phonemes, _) = g2p.g2p("Hello, world!");
+        let (phonemes, _) = g2p.g2p("Hello, world!").unwrap();
         println!("Phonemes: {}", phonemes);
         assert!(!phonemes.contains("❓"));
     }
@@ -375,7 +383,7 @@ mod tests {
             "how's",
         ];
         for text in cases {
-            let (p, _) = g2p.g2p(text);
+            let (p, _) = g2p.g2p(text).unwrap();
             println!("'{}' -> '{}'", text, p);
             assert!(!p.contains("❓"), "Failed for '{}'", text);
         }
@@ -386,7 +394,7 @@ mod tests {
         let g2p = G2P::new(Language::EnglishUS);
 
         // Test 1: All caps with suffix
-        let (playing, _) = g2p.g2p("PLAYING");
+        let (playing, _) = g2p.g2p("PLAYING").unwrap();
         println!("PLAYING: {}", playing);
         assert!(
             !playing.contains("❓"),
@@ -395,13 +403,13 @@ mod tests {
         );
 
         // Test 2: Contractions
-        let (ive, _) = g2p.g2p("I've");
+        let (ive, _) = g2p.g2p("I've").unwrap();
         println!("I've: {}", ive);
         assert!(!ive.contains("❓"), "I've should be resolved, got: {}", ive);
 
         // Test 3: Dashes
         // em-dash — (U+2014) and hyphen -
-        let (dash, _) = g2p.g2p("word - word — word");
+        let (dash, _) = g2p.g2p("word - word — word").unwrap();
         println!("Dash: {}", dash);
         assert!(
             !dash.contains("❓"),
@@ -425,7 +433,7 @@ mod tests {
             "",
         ];
         for text in cases {
-            let (p, _) = g2p.g2p(text);
+            let (p, _) = g2p.g2p(text).unwrap();
             println!("'{}' -> '{}'", text, p);
             if !text.is_empty() {
                 assert!(!p.is_empty(), "Failed for '{}'", text);
@@ -459,7 +467,7 @@ mod tests {
             "3.14159",
         ];
         for text in cases {
-            let (p, _) = g2p.g2p(text);
+            let (p, _) = g2p.g2p(text).unwrap();
             println!("'{}' -> '{}'", text, p);
             assert!(!p.is_empty(), "Failed for '{}'", text);
         }
@@ -495,7 +503,7 @@ mod tests {
             "na\u{00EF}ve", // ï as combining character
         ];
         for text in cases {
-            let (p, _) = g2p.g2p(text);
+            let (p, _) = g2p.g2p(text).unwrap();
             println!("'{}' -> '{}'", text, p);
             // Some might be empty/unknown depending on handling, but shouldn't crash
         }
@@ -529,7 +537,7 @@ mod tests {
             "\r\n",
         ];
         for text in cases {
-            let (p, _) = g2p.g2p(text);
+            let (p, _) = g2p.g2p(text).unwrap();
             println!("'{}' -> '{}'", text, p);
         }
     }
@@ -539,7 +547,7 @@ mod tests {
         let g2p = G2P::new(Language::EnglishUS);
         // Reduced to 100 to check if it crashes
         let long_text = "a".repeat(1000);
-        let (p, _) = g2p.g2p(&long_text);
+        let (p, _) = g2p.g2p(&long_text).unwrap();
         assert!(!p.is_empty());
     }
 }


### PR DESCRIPTION
This change addresses portability and build issues in misaki-rs by switching to the espeak-rs crate and configuring espeakng-sys for better libclang compatibility. It also introduces thread-safety to the fallback mechanism to prevent crashes during parallel execution.

Fixes #3

---
*PR created automatically by Jules for task [11187314221112122211](https://jules.google.com/task/11187314221112122211) started by @gad2103*